### PR TITLE
Fix player metadata not working in Plasma KDE

### DIFF
--- a/service.py
+++ b/service.py
@@ -51,6 +51,9 @@ class MprisServer(dbus.service.Object):
             'CanQuit': False,
             'CanRaise': False,
             'HasTrackList': False,
+            'SupportedUriSchemes': ['http', 'file', 'smb'],
+            'SupportedMimeTypes': ['audio/aac', 'audio/m4a', 'audio/mp3', 'audio/wav', 'audio/wma', 'audio/x-ape',
+                'audio/x-flac', 'audio/x-ogg', 'audio/x-oggflac', 'audio/x-vorbis'],
         }, signature='sv')
 
         self._current_position = 0


### PR DESCRIPTION
Plasma KDE is ignoring non-standards compliant players.

See here: https://github.com/KDE/plasma-workspace/commit/8eec2cfd36c4ecf9e2b13f4226ed49495271a1e2#diff-19867a87b2583d81920acad1cf500a89

This PR adds properties to make FeelUOwn recognized by KDE Plasma.